### PR TITLE
new meta.yaml file, tweak test imports to pass

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "pastml" %}
+{% set version = "1.9.34" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/evolbioinfo/pastml/archive/{{ version }}{{ version }}.tar.gz
+  sha256: 3ac606b5db79dc311110aa9a19a344ca28797275f174218b095e7874140f70da
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  build:
+  host:
+    - python
+    - pip
+  skip:
+  run:
+    - python
+    - ete3
+    - pandas
+    - numpy
+    - jinja2
+    - scipy
+    - itolapi
+    - biopython
+
+test:
+  imports:
+    - pastml
+  requires:
+    - python
+    - pip
+  commands:
+    - pip check
+    - cd tests/; python -m unittest *.py; cd ..
+
+about:
+  home: https://pastml.pasteur.fr
+  summary: 'Ancestor character reconstruction and visualisation for rooted phylogenetic trees'
+  description: |
+    PastML provides fast methods for Ancestral Character Reconstruction (ACR)
+    and visualisation on rooted phylogenetic trees. Given a rooted tree and its
+    node annotations, it can either visualise them as-is, or infer ancestral
+    node states based on the tip states, with a selection of maximum likelihood
+    and parsimonious methods. The result is then visualised as a zoomable html
+    map.
+  license: GPL-3.0
+  license_family: GPL
+  license_file: LICENSE
+  doc_url: https://pastml.pasteur.fr/help
+  dev_url: https://github.com/evolbioinfo/pastml
+
+extra:
+  recipe-maintainers:
+    - harmsm

--- a/pastml/utilities/state_simulator.py
+++ b/pastml/utilities/state_simulator.py
@@ -2,8 +2,8 @@ from collections import Counter
 
 import numpy as np
 
-from annotation import get_forest_stats
-from ml import get_pij_method
+from ..annotation import get_forest_stats
+from ..ml import get_pij_method
 
 
 def simulate_states(tree, model, frequencies, kappa, tau, sf, character, rate_matrix=None, n_repetitions=1_000):
@@ -35,7 +35,3 @@ def simulate_states(tree, model, frequencies, kappa, tau, sf, character, rate_ma
         n.add_feature(character, random_states)
 
     return tree
-
-
-
-

--- a/tests/MRANDJCTest.py
+++ b/tests/MRANDJCTest.py
@@ -10,7 +10,7 @@ from pastml.annotation import preannotate_forest, get_forest_stats
 from pastml.ml import marginal_counts
 from pastml.models.f81_like import JC
 from pastml.tree import read_tree
-from utilities.state_simulator import simulate_states
+from pastml.utilities.state_simulator import simulate_states
 
 DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data')
 TREE_NWK = os.path.join(DATA_DIR, 'Albanian.minitree.tre')
@@ -70,9 +70,3 @@ class MRANDJCTest(unittest.TestCase):
                 self.assertAlmostEqual(counts[i, j], sim_counts[i, j], 2,
                                        'Counts are different for {}->{}: {} (calculated) vs {} (simulated).'
                                        .format(states[i], states[j], counts[i, j], sim_counts[i, j]))
-
-
-
-
-
-

--- a/tests/PijTest.py
+++ b/tests/PijTest.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from models.hky import A, G, T, C, get_hky_pij
+from pastml.models.hky import A, G, T, C, get_hky_pij
 from pastml.ml import get_f81_pij, get_mu
 from pastml.models.generator import get_pij_matrix, get_diagonalisation
 


### PR DESCRIPTION
After I posted the [conda-forge submission request](https://github.com/evolbioinfo/pastml/issues/17), I (maybe presumptuously :) ) created a draft submission for pastml to conda-forge. 

# Changes
- Made a draft meta.yaml file for a conda-forge submission.
- Tweaked a couple of imports to convince the tests to run

It is passing all tests (macOS 12.4, M1 arm64) when sent in as :

```
cd tests
python -m unittest *.py
```

