### PR TITLE
change scipy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     url='https://github.com/evolbioinfo/pastml',
     keywords=['PASTML', 'visualisation', 'phylogeny', 'ancestral character reconstruction'],
     python_requires='>=3.10',
-    install_requires=['ete3>=3.1.1', 'pandas>=1.0.0', 'numpy<2.3,>=1.23.5', 'jinja2>=2.11.0', 'scipy==1.14.0', 'itolapi>=4.0.0', 'biopython>=1.70'],
+    install_requires=['ete3>=3.1.1', 'pandas>=1.0.0', 'numpy<2.3,>=1.23.5', 'jinja2>=2.11.0', 'scipy==1.14.1', 'itolapi>=4.0.0', 'biopython>=1.70'],
     entry_points={
             'console_scripts': [
                 'pastml = pastml.acr:main',


### PR DESCRIPTION
Change scipy version to 1.14.1 as 1.14.0 could not be installed on macOS 26 with python 3.13.